### PR TITLE
None: Reduce DualConnectionPerfIT flakiness on GH actions

### DIFF
--- a/src/test/java/com/atlassian/db/replica/it/DualConnectionPerfIT.java
+++ b/src/test/java/com/atlassian/db/replica/it/DualConnectionPerfIT.java
@@ -29,7 +29,7 @@ public class DualConnectionPerfIT {
         float thruputPerMillis = (float) times / duration.toMillis();
         assertThat(thruputPerMillis)
             .as("thruput per ms")
-            .isGreaterThan(3_500);
+            .isGreaterThan(3_000);
     }
 
     private Duration runBenchmark(Connection connection, int times) throws SQLException {


### PR DESCRIPTION
It seems that GH action's infrastructure is flakier and can process the
`micro-benchmark` slower than we expect. 3k/ms is still an acceptable
thruput.