### PR TITLE
Statement Behavior changes should not affect DualConnection's state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ### Fixed
 - Avoid unnecessary switch to `MainConnection` while setting `read-only` mode
+- Statement Behavior changes don't affect DualConnection's state
 
 ## [0.1.24] - 2021-02-16
 

--- a/src/main/java/com/atlassian/db/replica/internal/ReplicaStatement.java
+++ b/src/main/java/com/atlassian/db/replica/internal/ReplicaStatement.java
@@ -185,8 +185,15 @@ public class ReplicaStatement implements Statement {
     @Override
     public boolean execute(String sql) throws SQLException {
         checkClosed();
-        final RouteDecisionBuilder decisionBuilder = new RouteDecisionBuilder(RW_API_CALL).sql(sql);
-        final Statement statement = getWriteStatement(decisionBuilder);
+        final RouteDecisionBuilder decisionBuilder;
+        final Statement statement;
+        if (sql.startsWith("set")) {
+            decisionBuilder = new RouteDecisionBuilder(READ_OPERATION).sql(sql);
+            statement = getReadStatement(decisionBuilder);
+        } else {
+            decisionBuilder = new RouteDecisionBuilder(RW_API_CALL).sql(sql);
+            statement = getWriteStatement(decisionBuilder);
+        }
         return execute(
             () -> statement.execute(sql),
             decisionBuilder.build()


### PR DESCRIPTION
In our client's code `ConnectionUtils#withTimeout` sets `statement_timeout` before
executing queries. It was switching DualConnection to `MainConnection` state even
for read operations.