### PR TITLE
Avoid unnecessary switch to `MainConnection` while setting `read-only` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-0.1.24...master
 
+### Fixed
+- Avoid unnecessary switch to `MainConnection` while setting `read-only` mode
+
 ## [0.1.24] - 2021-02-16
 
 ### Added

--- a/src/main/java/com/atlassian/db/replica/internal/ReplicaConnectionProvider.java
+++ b/src/main/java/com/atlassian/db/replica/internal/ReplicaConnectionProvider.java
@@ -81,12 +81,8 @@ public class ReplicaConnectionProvider implements AutoCloseable {
     }
 
     public void setReadOnly(boolean readOnly) throws SQLException {
-        isReadOnly = readOnly;
-        if (readOnly) {
-            state.getReadConnection(new RouteDecisionBuilder(RO_API_CALL)).setReadOnly(readOnly);
-        } else {
-            state.getWriteConnection(new RouteDecisionBuilder(Reason.RW_API_CALL)).setReadOnly(isReadOnly);
-        }
+        this.isReadOnly = readOnly;
+        state.getReadConnection(new RouteDecisionBuilder(RO_API_CALL)).setReadOnly(readOnly);
     }
 
     public String getCatalog() {

--- a/src/test/java/com/atlassian/db/replica/api/TestDualConnection.java
+++ b/src/test/java/com/atlassian/db/replica/api/TestDualConnection.java
@@ -783,9 +783,24 @@ public class TestDualConnection {
         connection.setReadOnly(false);
 
         assertThat(connectionProvider.getProvidedConnectionTypes())
-            .containsOnly(MAIN);
+            .containsOnly(REPLICA);
         verify(connectionProvider.singleProvidedConnection()).setReadOnly(false);
         assertThat(connection.isReadOnly()).isFalse();
+    }
+
+    @Test
+    public void shouldUtiliseReplicaEvenAfterDisablingReadOnly() throws SQLException {
+        final ConnectionProviderMock connectionProvider = new ConnectionProviderMock();
+        final Connection connection = DualConnection.builder(
+            connectionProvider,
+            permanentConsistency().build()
+        ).build();
+
+        connection.setReadOnly(false);
+        connection.prepareStatement(SIMPLE_QUERY).executeQuery();
+
+        assertThat(connectionProvider.getProvidedConnectionTypes())
+            .containsOnly(REPLICA);
     }
 
     @Test
@@ -796,12 +811,11 @@ public class TestDualConnection {
             permanentConsistency().build()
         ).build();
 
-        connection.setReadOnly(false);
-        connection.setReadOnly(true);
+        connection.prepareStatement(SIMPLE_QUERY).executeUpdate();
+        connection.prepareStatement(SIMPLE_QUERY).executeQuery();
 
         assertThat(connectionProvider.getProvidedConnectionTypes())
             .containsOnly(MAIN);
-        assertThat(connection.isReadOnly()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
As per JavaDoc `read-only` mode is just a hint to the driver to enable
optimisations. In the case of `DualConnection` switching to the main just in case
is anti-optimisation.

I found out we set it to `false` just in case in `DatabaseAccessorImpl#runInTransaction`.
There might be more places like this, that prevent us from utilising replica more.