### PR TITLE
Introduce and use the experiment's API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-0.1.27...master
 
+### Added
+- Add support for `Experiment`'s
+
 ## [0.1.27] - 2021-02-23
 [0.1.27]: https://github.com/atlassian-labs/db-replica/compare/release-0.1.26...release-0.1.27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ### Added
 - Add support for `Experiment`'s
 
+### Fixed
+- `Connection#nativeSQL` uses replica database
+
 ## [0.1.27] - 2021-02-23
 [0.1.27]: https://github.com/atlassian-labs/db-replica/compare/release-0.1.26...release-0.1.27
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It integrates at the `java.sql.Connection` level, so you don't have to hunt down
 - [Configurable circuit breaker](src/main/java/com/atlassian/db/replica/spi/circuitbreaker/CircuitBreaker.java).
 - [Configurable main/replica split instrumentation](docs/split-instrumentation.md).
 - [Connection state change listener](src/main/java/com/atlassian/db/replica/spi/state/StateListener.java).
+- [Experiments](docs/experiments.md).
 
 ## Usage
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -18,4 +18,4 @@ You can inject your implementation of `Experiment` via the `DualConnection` buil
 
 
 
-Experiments are short living. It's expected to remove it with the next releases.
+Experiments are short-lived. It's expected to remove it with the next releases.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -14,7 +14,7 @@ You can inject your implementation of `Experiment` via the `DualConnection` buil
 
 ## Current experiments
 
-none
+- `com.atlassian.db.replica.experiment.nativesql.on.replica` - controls "`Connection#nativeSQL` uses replica database" fix
 
 
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1,0 +1,21 @@
+## Experiments
+
+`Experiments` is an API to change the behaviour of the library [on the fly](https://martinfowler.com/articles/feature-toggles.html).
+The API is transparent, you need to `opt-in` to take control over the change.
+
+### Why
+
+This technique allows for safer rollouts of features and bugfixes than just bumping a library.
+
+### How
+
+You can inject your implementation of `Experiment` via the `DualConnection` builder.
+
+
+## Current experiments
+
+none
+
+
+
+Experiments are short living. It's expected to remove it with the next releases.

--- a/src/main/java/com/atlassian/db/replica/api/DualConnection.java
+++ b/src/main/java/com/atlassian/db/replica/api/DualConnection.java
@@ -9,6 +9,7 @@ import com.atlassian.db.replica.internal.circuitbreaker.BreakerConnection;
 import com.atlassian.db.replica.internal.circuitbreaker.BreakerHandler;
 import com.atlassian.db.replica.spi.ConnectionProvider;
 import com.atlassian.db.replica.spi.DatabaseCall;
+import com.atlassian.db.replica.spi.Experiment;
 import com.atlassian.db.replica.spi.ReplicaConsistency;
 import com.atlassian.db.replica.spi.circuitbreaker.CircuitBreaker;
 import com.atlassian.db.replica.spi.state.StateListener;
@@ -28,18 +29,21 @@ public final class DualConnection implements Connection {
     private final ReplicaConsistency consistency;
     private final DatabaseCall databaseCall;
     private final Set<String> readOnlyFunctions;
+    private final Experiments experiments;
 
     private DualConnection(
         ConnectionProvider connectionProvider,
         ReplicaConsistency consistency,
         DatabaseCall databaseCall,
         StateListener stateListener,
-        Set<String> readOnlyFunctions
+        Set<String> readOnlyFunctions,
+        Experiments experiments
     ) {
         this.connectionProvider = new ReplicaConnectionProvider(connectionProvider, consistency, stateListener);
         this.consistency = consistency;
         this.databaseCall = databaseCall;
         this.readOnlyFunctions = readOnlyFunctions;
+        this.experiments = experiments;
     }
 
     @Override
@@ -486,6 +490,7 @@ public final class DualConnection implements Connection {
         private CircuitBreaker circuitBreaker = new BreakOnNotSupportedOperations();
         private StateListener stateListener = new NoOpStateListener();
         private Set<String> readOnlyFunctions = new HashSet<>();
+        private Collection<Experiment> experiments = new HashSet<>();
 
         private Builder(
             ConnectionProvider connectionProvider,
@@ -520,6 +525,11 @@ public final class DualConnection implements Connection {
             return this;
         }
 
+        public DualConnection.Builder experiments(Collection<Experiment> experiments) {
+            this.experiments = new HashSet<>(experiments);
+            return this;
+        }
+
         public Connection build() throws SQLException {
             if (circuitBreaker == null) {
                 return new DualConnection(
@@ -527,7 +537,8 @@ public final class DualConnection implements Connection {
                     consistency,
                     databaseCall,
                     stateListener,
-                    readOnlyFunctions
+                    readOnlyFunctions,
+                    new Experiments(this.experiments)
                 );
             }
             if (circuitBreaker.getState().equals(BreakerState.OPEN)) {
@@ -539,7 +550,8 @@ public final class DualConnection implements Connection {
                 consistency,
                 databaseCall,
                 stateListener,
-                readOnlyFunctions
+                readOnlyFunctions,
+                new Experiments(this.experiments)
             );
             return new BreakerConnection(dualConnection, breakerHandler);
         }

--- a/src/main/java/com/atlassian/db/replica/internal/Experiments.java
+++ b/src/main/java/com/atlassian/db/replica/internal/Experiments.java
@@ -1,0 +1,28 @@
+package com.atlassian.db.replica.internal;
+
+import com.atlassian.db.replica.spi.Experiment;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Experiments {
+    private final Map<String, Experiment> experimentsMap;
+
+    public Experiments(Collection<Experiment> experiments) {
+        final Map<String, Experiment> experimentsByKey = new HashMap<>();
+        for (Experiment experiment : experiments) {
+            experimentsByKey.put(experiment.getKey(), experiment);
+        }
+        this.experimentsMap = experimentsByKey;
+    }
+
+    public boolean isEnabled(String key) {
+        final Experiment experiment = experimentsMap.get(key);
+        if (experiment == null) {
+            return true;
+        } else {
+            return experiment.isEnabled();
+        }
+    }
+}

--- a/src/main/java/com/atlassian/db/replica/spi/Experiment.java
+++ b/src/main/java/com/atlassian/db/replica/spi/Experiment.java
@@ -1,0 +1,7 @@
+package com.atlassian.db.replica.spi;
+
+public interface Experiment {
+    String getKey();
+
+    boolean isEnabled();
+}

--- a/src/test/java/com/atlassian/db/replica/internal/ExperimentsTest.java
+++ b/src/test/java/com/atlassian/db/replica/internal/ExperimentsTest.java
@@ -1,0 +1,44 @@
+package com.atlassian.db.replica.internal;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ExperimentsTest {
+
+    @Test
+    public void shouldBeEnabledByDefault() {
+        final Experiments experiments = new Experiments(Collections.emptyList());
+
+        final boolean featureEnabled = experiments.isEnabled("test");
+
+        Assertions.assertThat(featureEnabled).isTrue();
+    }
+
+    @Test
+    public void shouldBeEnabled() {
+        final Experiments experiments = new Experiments(
+            of(new StaticExperiment("test", true), new StaticExperiment("test2", false))
+        );
+
+        final boolean featureEnabled = experiments.isEnabled("test");
+
+        Assertions.assertThat(featureEnabled).isTrue();
+    }
+
+    @Test
+    public void shouldBeDisabled() {
+        final Experiments experiments = new Experiments(
+            of(new StaticExperiment("test", true), new StaticExperiment("test2", false))
+        );
+
+        final boolean featureEnabled = experiments.isEnabled("test2");
+
+        Assertions.assertThat(featureEnabled).isFalse();
+    }
+
+
+}

--- a/src/test/java/com/atlassian/db/replica/internal/StaticExperiment.java
+++ b/src/test/java/com/atlassian/db/replica/internal/StaticExperiment.java
@@ -1,0 +1,24 @@
+package com.atlassian.db.replica.internal;
+
+import com.atlassian.db.replica.spi.Experiment;
+
+public final class StaticExperiment implements Experiment {
+    private final boolean enabled;
+    private final String key;
+
+
+    public StaticExperiment(String key, boolean enabled) {
+        this.key = key;
+        this.enabled = enabled;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+}


### PR DESCRIPTION
Currently, we are dealing with the problem of rolling out multiple changes at once. It forced us to disable the whole feature. We should not make the same mistake in the future.

The first commit introduces the Experiment API. The second one shows how to use it on a simple bugfix.