### PR TITLE
Harden Connection#close

### DIFF
--- a/src/main/java/com/atlassian/db/replica/internal/state/ConnectionState.java
+++ b/src/main/java/com/atlassian/db/replica/internal/state/ConnectionState.java
@@ -210,7 +210,7 @@ public final class ConnectionState {
             } catch (Exception e) {
                 warnings.saveWarning(new SQLWarning(e));
             }
-            if (parameters.isReadOnly()) {
+            if (connection.isReadOnly()) {
                 connection.setAutoCommit(true);
                 connection.setReadOnly(false);
             }

--- a/src/test/java/com/atlassian/db/replica/api/TestDualConnection.java
+++ b/src/test/java/com/atlassian/db/replica/api/TestDualConnection.java
@@ -1420,18 +1420,17 @@ public class TestDualConnection {
 
     @Test
     public void shouldResetReadOnlyModeBeforeReleasingConnection() throws SQLException {
-        final ConnectionProviderMock connectionProvider = new ConnectionProviderMock();
-        final Connection connection = DualConnection.builder(
-            connectionProvider,
+        final Connection connection = new ConnectionMock();
+        final SingleConnectionProvider singleConnectionProvider = new SingleConnectionProvider(connection);
+        final Connection dualConnection = DualConnection.builder(
+            singleConnectionProvider,
             permanentConsistency().build()
         ).build();
-        connection.setReadOnly(true);
-        connection.prepareStatement(SIMPLE_QUERY).executeQuery();
-        final Connection rawConnection = connectionProvider.singleProvidedConnection();
-        Mockito.reset(rawConnection);
+        dualConnection.setReadOnly(true);
+        dualConnection.prepareStatement(SIMPLE_QUERY).executeQuery();
 
-        connection.close();
+        dualConnection.close();
 
-        Mockito.verify(rawConnection).setReadOnly(eq(false));
+        Assertions.assertThat(connection.isReadOnly()).isFalse();
     }
 }


### PR DESCRIPTION
We ensure `ConnectionParameters` is in sync with the currently used connection, so it should not matter if we check the state from
the connection or parameters, but checking it directly on
a connection seems to be less error-prone.