### PR TITLE
Issue/jces 1896 is write api sql draft

### DIFF
--- a/src/main/java/com/atlassian/db/replica/api/reason/RouteDecision.java
+++ b/src/main/java/com/atlassian/db/replica/api/reason/RouteDecision.java
@@ -14,11 +14,21 @@ public final class RouteDecision {
     private final Reason reason;
     private final String sql;
     private final RouteDecision cause;
+    private final Boolean isWrite;
 
     public RouteDecision(String sql, Reason reason, RouteDecision cause) {
         this.sql = sql;
         this.reason = reason;
         this.cause = cause;
+        this.isWrite = null;
+    }
+
+    public RouteDecision(String sql, Reason reason, RouteDecision cause, Boolean isWrite) {
+        this.sql = sql;
+        this.reason = reason;
+        this.cause = cause;
+        this.isWrite = isWrite;
+
     }
 
     /**
@@ -42,13 +52,8 @@ public final class RouteDecision {
         return Optional.ofNullable(cause);
     }
 
-    /**
-     * @return information whether reason was caused by write sql operation.
-     */
-    public boolean isWrite(){
-        return WRITE_OPERATION.equals(reason) ||
-                LOCK.equals(reason) ||
-                RW_API_CALL.equals(reason);
+    public Boolean getWrite() {
+        return isWrite;
     }
 
     /**
@@ -58,21 +63,22 @@ public final class RouteDecision {
         return reason.isRunOnMain();
     }
 
-
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         RouteDecision that = (RouteDecision) o;
-        return Objects.equals(reason, that.reason) && Objects.equals(
-                sql,
-                that.sql
-        ) && Objects.equals(cause, that.cause);
+        return Objects.equals(reason, that.reason) && Objects.equals(sql, that.sql) && Objects
+                .equals(cause, that.cause) && Objects.equals(isWrite, that.isWrite);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(reason, sql, cause);
+        return Objects.hash(reason, sql, cause, isWrite);
     }
 
     @Override
@@ -81,6 +87,7 @@ public final class RouteDecision {
                 "reason=" + reason +
                 ", sql='" + sql + '\'' +
                 ", cause=" + cause +
+                ", isWrite=" + isWrite +
                 '}';
     }
 }

--- a/src/main/java/com/atlassian/db/replica/api/reason/RouteDecision.java
+++ b/src/main/java/com/atlassian/db/replica/api/reason/RouteDecision.java
@@ -3,6 +3,10 @@ package com.atlassian.db.replica.api.reason;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.atlassian.db.replica.api.reason.Reason.LOCK;
+import static com.atlassian.db.replica.api.reason.Reason.RW_API_CALL;
+import static com.atlassian.db.replica.api.reason.Reason.WRITE_OPERATION;
+
 /**
  * Reveals details related to why, and which database will be used.
  */
@@ -38,14 +42,31 @@ public final class RouteDecision {
         return Optional.ofNullable(cause);
     }
 
+    /**
+     * @return information whether reason was caused by write sql operation.
+     */
+    public boolean isWrite(){
+        return WRITE_OPERATION.equals(reason) ||
+                LOCK.equals(reason) ||
+                RW_API_CALL.equals(reason);
+    }
+
+    /**
+     * @return whether sql was run on Main
+     */
+    public boolean isRunOnMain() {
+        return reason.isRunOnMain();
+    }
+
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RouteDecision that = (RouteDecision) o;
         return Objects.equals(reason, that.reason) && Objects.equals(
-            sql,
-            that.sql
+                sql,
+                that.sql
         ) && Objects.equals(cause, that.cause);
     }
 
@@ -57,9 +78,9 @@ public final class RouteDecision {
     @Override
     public String toString() {
         return "RouteDecision{" +
-            "reason=" + reason +
-            ", sql='" + sql + '\'' +
-            ", cause=" + cause +
-            '}';
+                "reason=" + reason +
+                ", sql='" + sql + '\'' +
+                ", cause=" + cause +
+                '}';
     }
 }

--- a/src/main/java/com/atlassian/db/replica/internal/ReplicaPreparedStatement.java
+++ b/src/main/java/com/atlassian/db/replica/internal/ReplicaPreparedStatement.java
@@ -380,6 +380,7 @@ public class ReplicaPreparedStatement extends ReplicaStatement implements Prepar
         if (currentStatement != null) {
             return currentStatement.getParameterMetaData();
         } else {
+            //todo writeStatment not always is used for write SQL queries
             return getWriteStatement(new RouteDecisionBuilder(RW_API_CALL)).getParameterMetaData();
         }
     }

--- a/src/main/java/com/atlassian/db/replica/internal/RouteDecisionBuilder.java
+++ b/src/main/java/com/atlassian/db/replica/internal/RouteDecisionBuilder.java
@@ -9,6 +9,8 @@ public final class RouteDecisionBuilder {
     private String sql = null;
     private Reason reason;
     private RouteDecision cause = null;
+    private Boolean isWrite  = null;
+
 
     public RouteDecisionBuilder(Reason reason) {
         this.reason = reason;
@@ -29,12 +31,17 @@ public final class RouteDecisionBuilder {
         return this;
     }
 
+    public RouteDecisionBuilder isWrite(final boolean isWrite) {
+        this.isWrite = isWrite;
+        return this;
+    }
+
     public String getSql() {
         return sql;
     }
 
     public RouteDecision build() {
-        return new RouteDecision(sql, reason, cause);
+        return new RouteDecision(sql, reason, cause, isWrite);
     }
 
     @Override

--- a/src/main/java/com/atlassian/db/replica/internal/SQLOpeartionType.java
+++ b/src/main/java/com/atlassian/db/replica/internal/SQLOpeartionType.java
@@ -1,0 +1,50 @@
+package com.atlassian.db.replica.internal;
+
+public class SQLOpeartionType {
+
+    public static enum SQLType {
+        WRITE, READ_ONLY, NOT_KNOWN
+    }
+
+    private final SqlFunction sqlFunction;
+
+    public SQLOpeartionType(SqlFunction sqlFunction) {
+        this.sqlFunction = sqlFunction;
+    }
+
+    /**
+     * Arbitrially judge based on sql param whether sql is WRITE
+     */
+    public boolean whetherSQLisWrite(String sql){
+        //method to arbitrially judge whether sql isWrite or
+        //maybe inspired MaryPri
+        //https://bitbucket.org/atlassian/marypri/src/00f9cad9d58131e6d9d27be8de0ee5d01b3cbfd3/src/main/kotlin/io/atlassian/micros/marypri/sql/ReadWriteClassifier.kt#lines-14
+        return isWriteOpearation(sql) &&
+                isSelectForUpdate(sql) &&
+                !isSQLSet(sql);
+    }
+
+
+    public boolean isWriteOpearation(String sql) {
+        boolean isWriteOperation = sqlFunction.isFunctionCall(sql) || isUpdate(sql) || isDelete(sql);
+
+        return isWriteOperation;
+
+    }
+
+    public boolean isSelectForUpdate(String sql) {
+        return sql != null && (sql.endsWith("for update") || sql.endsWith("FOR UPDATE"));
+    }
+
+    public boolean isSQLSet(String sql) {
+        return sql.startsWith("set");
+    }
+
+    public boolean isUpdate(String sql) {
+        return sql != null && (sql.startsWith("update") || sql.startsWith("UPDATE"));
+    }
+
+    public boolean isDelete(String sql) {
+        return sql != null && (sql.startsWith("delete") || sql.startsWith("DELETE"));
+    }
+}

--- a/src/test/java/com/atlassian/db/replica/api/reason/TestRouteDecision.java
+++ b/src/test/java/com/atlassian/db/replica/api/reason/TestRouteDecision.java
@@ -1,0 +1,44 @@
+package com.atlassian.db.replica.api.reason;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class TestRouteDecision {
+
+    private static final RouteDecision READ_DECISION = new RouteDecision("select * from somewhere", Reason.READ_OPERATION, null);
+    private static final RouteDecision WRITE_DECISION = new RouteDecision("select * from somewhere", Reason.WRITE_OPERATION, null);
+    private static final RouteDecision WRITE_DECISION2 = new RouteDecision("select * from somewhere", Reason.LOCK, null);
+    private static final RouteDecision WRITE_DECISION3 = new RouteDecision("select * from somewhere", Reason.RW_API_CALL, null);
+
+    @Parameters
+    public static Collection routeDecisions() {
+        return Arrays.asList(new Object[][]{
+                {READ_DECISION, false},
+                {WRITE_DECISION, true},
+                {WRITE_DECISION2, true},
+                {WRITE_DECISION3, true},
+        });
+    }
+
+    private RouteDecision givenRouteDecision;
+    private boolean expectedIsWrite;
+
+    public TestRouteDecision(RouteDecision givenRouteDecision, boolean expectedIsWrite) {
+        this.givenRouteDecision = givenRouteDecision;
+        this.expectedIsWrite = expectedIsWrite;
+    }
+
+    @Test
+    public void shouldDetectWriteDatabaseCallAndRunReleatedObservedAction() {
+        assertThat(givenRouteDecision.isWrite()).isEqualTo(expectedIsWrite);
+    }
+
+}


### PR DESCRIPTION
JCES-1896 draft - I'm trying to find the ultimate answer for how to judge whether sql is read/write and where is best place (is there possibility to increase coverage by more readQueries moved to Replica). How SQL operation is treated in db-replica is based on statementType + sql + consistency. Is there a way to arbitrarily judge whether SQL is read/write?