### PR TITLE
Mark release `1.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-0.1.31...master
+[Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-1.0.0...master
+
+## [1.0.0] - 2021-03-15
+[1.0.0]: https://github.com/atlassian-labs/db-replica/compare/release-0.1.30...release-1.0.0
 
 ### Removed
 - `DualConnection.Builder.stateListener()`

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Maven:
 <dependency>
     <groupId>com.atlassian.db.replica</groupId>
     <artifactId>db-replica</artifactId>
-    <version>0.1.31</version>
+    <version>1.0.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
By approving the PR, you're approving the `1.0.0` API. I will merge it after the release.

- [x] Release `db-replica` 1.0.0 first
- [ ] Make sure Aurora LSN can be implemented with the current version of `ReplicaConsistency`