### PR TITLE
another aurora function to fetch LSN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-1.1.0...master
 
+### Changed
+- `AuroraPostgresLsnReplicaConsistency` uses `aurora_replica_status()` function
+
 ## [1.1.0] - 2021-03-18
 [1.1.0]: https://github.com/atlassian-labs/db-replica/compare/release-1.0.0...release-1.1.0
 

--- a/src/main/java/com/atlassian/db/replica/api/AuroraPostgresLsnReplicaConsistency.java
+++ b/src/main/java/com/atlassian/db/replica/api/AuroraPostgresLsnReplicaConsistency.java
@@ -69,14 +69,14 @@ public final class AuroraPostgresLsnReplicaConsistency implements ReplicaConsist
      * @return LSN (log sequence number) for the main database (the highest LSN)
      */
     private long queryMainDbLsn(Connection connection) {
-        return queryLsn(connection, "SELECT MAX(durable_lsn) AS lsn FROM aurora_global_db_instance_status();");
+        return queryLsn(connection, "SELECT MAX(durable_lsn) AS lsn FROM aurora_replica_status();");
     }
 
     /**
      * @return LSN (log sequence number) for the most outdated replica database (the lowest LSN)
      */
     private long queryReplicaDbLsn(Connection connection) {
-        return queryLsn(connection, "SELECT MIN(durable_lsn) AS lsn FROM aurora_global_db_instance_status();");
+        return queryLsn(connection, "SELECT MIN(durable_lsn) AS lsn FROM aurora_replica_status();");
     }
 
     private long queryLsn(Connection connection, String rawSqlQuery) {


### PR DESCRIPTION
Previous aurora function `aurora_global_db_instance_status` to fetch LSN was quite slow. It is a chance that this one (`aurora_replica_status`) will be better and we have nothing to loose to verify it.