### PR TITLE
Remove `Thread.sleep` from `ThrottledCacheTest`

### DIFF
--- a/src/test/java/com/atlassian/db/replica/api/ThrottledCacheTest.java
+++ b/src/test/java/com/atlassian/db/replica/api/ThrottledCacheTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.util.ConcurrentModificationException;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -56,9 +57,11 @@ public class ThrottledCacheTest {
 
 
     private void asyncPutWithSlowSupplier(ThrottledCache<Long> cache, long value) throws InterruptedException {
+        final CountDownLatch asyncThreadStarted = new CountDownLatch(1);
         executor.submit(() -> {
             cache.get(() -> {
                 try {
+                    asyncThreadStarted.countDown();
                     Thread.sleep(1000);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
@@ -66,7 +69,7 @@ public class ThrottledCacheTest {
                 return value;
             });
         });
-        Thread.sleep(10);
+        asyncThreadStarted.await();
     }
 
     private Long anyValue() {


### PR DESCRIPTION
Before:
![Zrzut ekranu 2021-04-2 o 08 55 57](https://user-images.githubusercontent.com/3447570/113391056-3397e400-9393-11eb-9f27-807832d37daa.png)
After:
![Zrzut ekranu 2021-04-2 o 08 56 24](https://user-images.githubusercontent.com/3447570/113391080-3d214c00-9393-11eb-96cf-1c55626d5b4c.png)
And it should be less flake.

We can remove the second `Thread.sleep` as well. It will not affect the execution time but could make the test less flaky.