### PR TITLE
Reduce expected thruput due to new feature

### DIFF
--- a/src/test/java/com/atlassian/db/replica/it/DualConnectionPerfIT.java
+++ b/src/test/java/com/atlassian/db/replica/it/DualConnectionPerfIT.java
@@ -29,7 +29,7 @@ public class DualConnectionPerfIT {
         float thruputPerMillis = (float) times / duration.toMillis();
         assertThat(thruputPerMillis)
             .as("thruput per ms")
-            .isGreaterThan(2_500);
+            .isGreaterThan(2_200);
     }
 
     private Duration runBenchmark(Connection connection, int times) throws SQLException {


### PR DESCRIPTION
It seems the [trimming] costed around 10% of thruput.

[trimming]: 5641b8c21a670449814aa10db0df625f551336ff