### PR TITLE
Remove circuit breaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-1.2.4...master
 
+### Fixed
+- No circuit breaker by default.
+
 ## [1.2.4] - 2021-04-15
 [1.2.4]: https://github.com/atlassian-labs/db-replica/compare/release-1.2.2...release-1.2.4
 

--- a/src/main/java/com/atlassian/db/replica/api/DualConnection.java
+++ b/src/main/java/com/atlassian/db/replica/api/DualConnection.java
@@ -598,6 +598,9 @@ public final class DualConnection implements Connection {
         }
 
         public Connection build() throws SQLException {
+            if (!compatibleWithPreviousVersion) {
+                circuitBreaker = null;
+            }
             if (circuitBreaker == null) {
                 return new DualConnection(
                     connectionProvider,


### PR DESCRIPTION
There's no API for circuit breaker, so we should not enforce `BreakOnNotSupportedOperations`.
No circuit breaker is better because it allows users to implement circuit breaker
on an application level.

We also have feedback from other Atlassian teams that `BreakOnNotSupportedOperations`
doesn't fit their needs and they can't override it.

The other option would be to open CircuitBreaker API, but in past,
we decided not to publish CircuitBreaker in the current form as we started to work
on a better SPI (https://github.com/atlassian-labs/db-replica/pull/11). Better SPI is on hold now.