### PR TITLE
Add `preWrite` to `ReplicaConsistency`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Changing the license is breaking a contract.
 Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
+### Added
+- `ReplicaConsistency#preWrite()`
+
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-1.2.6...master
 

--- a/src/main/java/com/atlassian/db/replica/api/DualConnection.java
+++ b/src/main/java/com/atlassian/db/replica/api/DualConnection.java
@@ -62,7 +62,8 @@ public final class DualConnection implements Connection {
         this.connectionProvider = new ReplicaConnectionProvider(
             connectionProvider,
             consistency,
-            stateListener
+            stateListener,
+            compatibleWithPreviousVersion
         );
         this.consistency = consistency;
         this.databaseCall = databaseCall;

--- a/src/main/java/com/atlassian/db/replica/spi/ReplicaConsistency.java
+++ b/src/main/java/com/atlassian/db/replica/spi/ReplicaConsistency.java
@@ -12,11 +12,23 @@ import java.util.function.Supplier;
 public interface ReplicaConsistency {
 
     /**
-     * Informs that {@code main} received an UPDATE, INSERT or DELETE.
+     * Informs that {@code main} received an UPDATE, INSERT or DELETE or transaction commit
+     * when in a transaction.
      *
      * @param main connects to the main database
      */
     void write(Connection main);
+
+    /**
+     * Invoked just before transaction commit.
+     *
+     * Notice: The method will not handle all writes. Writes done outside of a transaction
+     * needs to be handled in `ReplicaConnection#write`.
+     *
+     * @param main connects to the main database
+     */
+    default void preCommit(Connection main){
+    }
 
     /**
      * Judges if {@code replica} is ready to be queried.


### PR DESCRIPTION
Internally we are experimenting with a new way of tracking inconsistencies. We
increase an integer in the transaction just after changes committed. We use
`ReplicaConsistency#write`. This approach has some disadvantages:
- it doubles the number of transactions. It also doubles the number of changes to be replicated. It may affect replication lag.
- we need two database calls to propagate the information (update + commit).
- We increase `inconsistency` time. We don't track when changes are propagated, but we handle changes after the changes are propagated.

`Connection#preWrite` allows us to inject our counter bump into the same transaction.