### PR TITLE
Replicas discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-1.3.0...master
 
+### Added
+- `AuroraReplicasDiscoverer`
+
 ## [1.3.0] - 2021-04-21
 [1.3.0]: https://github.com/atlassian-labs/db-replica/compare/release-1.2.6...release-1.3.0
 

--- a/src/main/java/com/atlassian/db/replica/api/aurora/AuroraReplicasDiscoverer.java
+++ b/src/main/java/com/atlassian/db/replica/api/aurora/AuroraReplicasDiscoverer.java
@@ -1,0 +1,55 @@
+package com.atlassian.db.replica.api.aurora;
+
+import com.atlassian.db.replica.internal.aurora.AuroraEndpoint;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.atlassian.db.replica.internal.aurora.AuroraEndpoints.instanceEndpoint;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * It allows to pull Aurora Replicas cluster information
+ */
+public final class AuroraReplicasDiscoverer {
+    private final Connection connection;
+
+    public AuroraReplicasDiscoverer(Connection connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * It provides list of replica endpoints based on reader endpoint and server ids
+     * @param readerEndpoint - Aurora reader endpoint
+     * @return list of replicas endpoints
+     * @throws SQLException
+     */
+    public List<AuroraEndpoint> fetchReplicasEndpoints(String readerEndpoint) throws SQLException {
+        return fetchReplicasServerIds()
+            .stream()
+            .map(serverId -> instanceEndpoint(readerEndpoint, serverId))
+            .collect(toList());
+    }
+
+    /**
+     * Asks Aurora about the list of server ids
+     * @return server ids
+     * @throws SQLException
+     */
+    public List<String> fetchReplicasServerIds() throws SQLException {
+        LinkedList<String> ids = new LinkedList<>();
+        try (ResultSet rs =
+                 connection.prepareStatement(
+                     "SELECT server_id FROM aurora_global_db_instance_status() WHERE session_id != 'MASTER_SESSION_ID'")
+                     .executeQuery()) {
+            while (rs.next()) {
+                ids.add(rs.getString("server_id"));
+            }
+        }
+        return ids;
+    }
+}
+

--- a/src/main/java/com/atlassian/db/replica/internal/aurora/AuroraCluster.java
+++ b/src/main/java/com/atlassian/db/replica/internal/aurora/AuroraCluster.java
@@ -1,0 +1,100 @@
+package com.atlassian.db.replica.internal.aurora;
+
+import java.util.Objects;
+
+import static com.atlassian.db.replica.internal.aurora.AuroraCluster.AuroraClusterBuilder.anAuroraCluster;
+
+public final class AuroraCluster {
+    private final String clusterName;
+    private final String clusterPrefix;
+
+    private AuroraCluster(String clusterName, String clusterPrefix) {
+        this.clusterName = clusterName;
+        this.clusterPrefix = clusterPrefix;
+    }
+
+    public static AuroraCluster parse(String cluster) {
+        Objects.requireNonNull(cluster);
+
+        String[] chunks = splitByLastOccurence("-", cluster);
+        if (chunks.length == 1) {
+            String clusterName = chunks[0];
+            return anAuroraCluster(clusterName).build();
+        } else {
+            String clusterName = chunks[0];
+            String clusterPrefix = chunks[1];
+            return anAuroraCluster(clusterName).clusterPrefix(clusterPrefix).build();
+        }
+    }
+
+    private static String[] splitByLastOccurence(String delimiter, String str) {
+        int i = str.lastIndexOf(delimiter);
+        if (i == -1) {
+            return new String[]{str};
+        } else {
+            return new String[]{str.substring(i + 1), str.substring(0, i)};
+        }
+    }
+
+    @Override
+    public String toString() {
+        if (clusterPrefix != null && !clusterPrefix.isEmpty()) {
+            return String.format("%s-%s", clusterPrefix, clusterName);
+        } else {
+            return clusterName;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AuroraCluster that = (AuroraCluster) o;
+
+        if (!Objects.equals(clusterName, that.clusterName)) return false;
+        return Objects.equals(clusterPrefix, that.clusterPrefix);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = clusterName != null ? clusterName.hashCode() : 0;
+        result = 31 * result + (clusterPrefix != null ? clusterPrefix.hashCode() : 0);
+        return result;
+    }
+
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public String getClusterPrefix() {
+        return clusterPrefix;
+    }
+
+
+    public static final class AuroraClusterBuilder {
+        private String clusterName;
+        private String clusterPrefix;
+
+        private AuroraClusterBuilder() {
+        }
+
+        public static AuroraClusterBuilder anAuroraCluster(String clusterName) {
+            return new AuroraClusterBuilder().clusterName(clusterName);
+        }
+
+        public AuroraClusterBuilder clusterName(String clusterName) {
+            this.clusterName = clusterName;
+            return this;
+        }
+
+        public AuroraClusterBuilder clusterPrefix(String clusterPrefix) {
+            this.clusterPrefix = clusterPrefix;
+            return this;
+        }
+
+        public AuroraCluster build() {
+            return new AuroraCluster(clusterName, clusterPrefix);
+        }
+    }
+}

--- a/src/main/java/com/atlassian/db/replica/internal/aurora/AuroraEndpoint.java
+++ b/src/main/java/com/atlassian/db/replica/internal/aurora/AuroraEndpoint.java
@@ -1,0 +1,87 @@
+package com.atlassian.db.replica.internal.aurora;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class AuroraEndpoint {
+    private static final Pattern ENDPOINT_PATTERN = Pattern.compile("([^.]+).([^.]+).(.*)");
+    private final String serverId;
+    private final AuroraCluster cluster;
+    private final RdsDns dns;
+
+    public AuroraEndpoint(String serverId, AuroraCluster cluster, RdsDns dns) {
+        this.serverId = serverId;
+        this.cluster = cluster;
+        this.dns = dns;
+    }
+
+    public static AuroraEndpoint parse(String readerEndpoint) {
+        Objects.requireNonNull(readerEndpoint);
+
+        Matcher matcher = ENDPOINT_PATTERN.matcher(readerEndpoint);
+        matcher.matches();
+        return new AuroraEndpoint(
+            matcher.group(1),
+            AuroraCluster.parse(matcher.group(2)),
+            RdsDns.parse(matcher.group(3))
+        );
+    }
+
+    public String getServerId() {
+        return serverId;
+    }
+
+    public AuroraCluster getCluster() {
+        return cluster;
+    }
+
+    public RdsDns getDns() {
+        return dns;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s.%s.%s", serverId, cluster.toString(), dns.toString());
+    }
+
+
+    public static final class AuroraEndpointBuilder {
+        private String serverId;
+        private AuroraCluster cluster;
+        private RdsDns dns;
+
+        private AuroraEndpointBuilder() {
+        }
+
+        public static AuroraEndpointBuilder anAuroraEndpoint(AuroraEndpoint endpoint) {
+            return new AuroraEndpointBuilder()
+                .serverId(endpoint.serverId)
+                .cluster(endpoint.cluster)
+                .dns(endpoint.dns);
+        }
+
+        public static AuroraEndpointBuilder anAuroraEndpoint() {
+            return new AuroraEndpointBuilder();
+        }
+
+        public AuroraEndpointBuilder serverId(String serverId) {
+            this.serverId = serverId;
+            return this;
+        }
+
+        public AuroraEndpointBuilder cluster(AuroraCluster cluster) {
+            this.cluster = cluster;
+            return this;
+        }
+
+        public AuroraEndpointBuilder dns(RdsDns dns) {
+            this.dns = dns;
+            return this;
+        }
+
+        public AuroraEndpoint build() {
+            return new AuroraEndpoint(serverId, cluster, dns);
+        }
+    }
+}

--- a/src/main/java/com/atlassian/db/replica/internal/aurora/AuroraEndpoints.java
+++ b/src/main/java/com/atlassian/db/replica/internal/aurora/AuroraEndpoints.java
@@ -1,0 +1,20 @@
+package com.atlassian.db.replica.internal.aurora;
+
+import static com.atlassian.db.replica.internal.aurora.AuroraCluster.AuroraClusterBuilder.anAuroraCluster;
+import static com.atlassian.db.replica.internal.aurora.AuroraEndpoint.AuroraEndpointBuilder.anAuroraEndpoint;
+
+public class AuroraEndpoints {
+    private AuroraEndpoints() {
+    }
+
+    /**
+     * Transforms reader endpoint to instance endpoint
+     */
+    public static AuroraEndpoint instanceEndpoint(String readerEndpoint, String serverId) {
+        AuroraEndpoint endpoint = AuroraEndpoint.parse(readerEndpoint);
+        return anAuroraEndpoint(endpoint)
+            .serverId(serverId)
+            .cluster(anAuroraCluster(endpoint.getCluster().getClusterName()).clusterPrefix(null).build())
+            .build();
+    }
+}

--- a/src/main/java/com/atlassian/db/replica/internal/aurora/RdsDns.java
+++ b/src/main/java/com/atlassian/db/replica/internal/aurora/RdsDns.java
@@ -1,0 +1,83 @@
+package com.atlassian.db.replica.internal.aurora;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class RdsDns {
+    private static final Pattern DNS_PATTERN = Pattern.compile("([^.]+).([^:]*):?([0-9]+)?");
+    private final String region;
+    private final String domain;
+    private final Integer port;
+
+    public RdsDns(String region, String domain, Integer port) {
+        this.region = region;
+        this.domain = domain;
+        this.port = port;
+    }
+
+    public static RdsDns parse(String dns) {
+        Objects.requireNonNull(dns);
+
+        Matcher matcher = DNS_PATTERN.matcher(dns);
+        matcher.matches();
+        return new RdsDns(matcher.group(1), matcher.group(2), parseNullableInteger(groupOrNull(matcher, 3)));
+    }
+
+    private static String groupOrNull(Matcher matcher, int n) {
+        try {
+            return matcher.group(n);
+        } catch (IndexOutOfBoundsException e) {
+            return null;
+        }
+    }
+
+    private static Integer parseNullableInteger(String str) {
+        if (str == null) {
+            return null;
+        } else {
+            return Integer.valueOf(str);
+        }
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    @Override
+    public String toString() {
+        if (port != null) {
+            return String.format("%s.%s:%s", region, domain, port);
+        } else {
+            return String.format("%s.%s", region, domain);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RdsDns rdsDns = (RdsDns) o;
+
+        if (!Objects.equals(region, rdsDns.region)) return false;
+        if (!Objects.equals(domain, rdsDns.domain)) return false;
+        return Objects.equals(port, rdsDns.port);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = region != null ? region.hashCode() : 0;
+        result = 31 * result + (domain != null ? domain.hashCode() : 0);
+        result = 31 * result + (port != null ? port.hashCode() : 0);
+        return result;
+    }
+}

--- a/src/test/java/com/atlassian/db/replica/api/aurora/AuroraClusterTest.java
+++ b/src/test/java/com/atlassian/db/replica/api/aurora/AuroraClusterTest.java
@@ -1,0 +1,24 @@
+package com.atlassian.db.replica.api.aurora;
+
+import com.atlassian.db.replica.internal.aurora.AuroraCluster;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuroraClusterTest {
+
+    @Test
+    void parseClusterWithoutPrefix() {
+        AuroraCluster cluster = AuroraCluster.parse("232938923");
+        assertNull(cluster.getClusterPrefix());
+        assertThat(cluster.getClusterName()).isEqualTo("232938923");
+    }
+
+    @Test
+    void parseCluster() {
+        AuroraCluster cluster = AuroraCluster.parse("cluster-pr-232938923");
+        assertThat(cluster.getClusterPrefix()).isEqualTo("cluster-pr");
+        assertThat(cluster.getClusterName()).isEqualTo("232938923");
+    }
+}

--- a/src/test/java/com/atlassian/db/replica/api/aurora/AuroraEndpointTest.java
+++ b/src/test/java/com/atlassian/db/replica/api/aurora/AuroraEndpointTest.java
@@ -1,0 +1,28 @@
+package com.atlassian.db.replica.api.aurora;
+
+import com.atlassian.db.replica.internal.aurora.AuroraEndpoint;
+import com.atlassian.db.replica.internal.aurora.RdsDns;
+import org.junit.jupiter.api.Test;
+
+import static com.atlassian.db.replica.internal.aurora.AuroraCluster.AuroraClusterBuilder.anAuroraCluster;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuroraEndpointTest {
+    @Test
+    void shouldParseReaderEndpoint() {
+        AuroraEndpoint endpoint = AuroraEndpoint.parse(
+            "mydbcluster.cluster-ro-123456789012.us-east-1.rds.amazonaws.com:3306");
+
+        assertThat(endpoint.getServerId()).isEqualTo("mydbcluster");
+        assertThat(endpoint.getCluster()).isEqualTo(anAuroraCluster("123456789012").clusterPrefix("cluster-ro").build());
+        assertThat(endpoint.getDns()).isEqualTo(new RdsDns("us-east-1", "rds.amazonaws.com", 3306));
+    }
+
+    @Test
+    void shouldToString() {
+        String original = "mydbcluster.cluster-ro-123456789012.us-east-1.rds.amazonaws.com:3306";
+        String fromStringToString = AuroraEndpoint.parse(original).toString();
+
+        assertThat(fromStringToString).isEqualTo(original);
+    }
+}

--- a/src/test/java/com/atlassian/db/replica/api/aurora/AuroraEndpointsTest.java
+++ b/src/test/java/com/atlassian/db/replica/api/aurora/AuroraEndpointsTest.java
@@ -1,0 +1,18 @@
+package com.atlassian.db.replica.api.aurora;
+
+import com.atlassian.db.replica.internal.aurora.AuroraEndpoints;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class AuroraEndpointsTest {
+    @Test
+    void shouldTransformClusterEndpointToInstanceEndpoint() {
+        String instanceEndpoint = AuroraEndpoints.instanceEndpoint(
+            "mydbcluster.cluster-ro-123456789012.us-east-1.rds.amazonaws.com:3306",
+            "mydbcluster-lr"
+        ).toString();
+
+        assertThat(instanceEndpoint).isEqualTo("mydbcluster-lr.123456789012.us-east-1.rds.amazonaws.com:3306");
+    }
+}

--- a/src/test/java/com/atlassian/db/replica/api/aurora/RdsDnsTest.java
+++ b/src/test/java/com/atlassian/db/replica/api/aurora/RdsDnsTest.java
@@ -1,0 +1,41 @@
+package com.atlassian.db.replica.api.aurora;
+
+import com.atlassian.db.replica.internal.aurora.RdsDns;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class RdsDnsTest {
+
+    @Test
+    void parseRdsDns() {
+        RdsDns dns = RdsDns.parse("us-east-1.rds.amazonaws.com:3306");
+
+        assertThat(dns.getRegion()).isEqualTo("us-east-1");
+        assertThat(dns.getDomain()).isEqualTo("rds.amazonaws.com");
+        assertThat(dns.getPort()).isEqualTo(3306);
+    }
+
+    @Test
+    void parseRdsDnsWithoutPort() {
+        RdsDns dns = RdsDns.parse("us-east-1.rds.amazonaws.com");
+
+        assertThat(dns.getRegion()).isEqualTo("us-east-1");
+        assertThat(dns.getDomain()).isEqualTo("rds.amazonaws.com");
+        assertThat(dns.getPort()).isEqualTo(null);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "us-east-1.rds.amazonaws.com:3306",
+        "us-east-1.rds.amazonaws.com",
+    })
+    void shouldSerializerToOriginalValue(String input) {
+        String output = RdsDns.parse(input).toString();
+
+        assertThat(output).isEqualTo(input);
+    }
+}


### PR DESCRIPTION
AuroraReplicasDiscoverer makes is easy to fetch direct urls to all replicas. It could be handy when you don't want to depend on default AWS load balancing.