### PR TITLE
Add replica failure strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-2.1.4...master
 
+### Added
+- Add `ReplicaFailureStrategy`
+
 ## [2.1.4] - 2021-07-08
 [2.1.4]: https://github.com/atlassian-labs/db-replica/compare/release-2.1.2...release-2.1.4
 

--- a/src/main/java/com/atlassian/db/replica/api/reason/Reason.java
+++ b/src/main/java/com/atlassian/db/replica/api/reason/Reason.java
@@ -32,6 +32,8 @@ public final class Reason {
             new ReasonBuilder("HIGH_TRANSACTION_ISOLATION_LEVEL").isRunOnMain(true).isWrite(false).build();
     public static final Reason RO_API_CALL =
             new ReasonBuilder("RO_API_CALL").isRunOnMain(false).isWrite(false).build();
+    public static final Reason REPLICA_GET_FAILURE =
+        new ReasonBuilder("REPLICA_GET_FAILURE").isRunOnMain(true).isWrite(false).build();
 
     public String getName() {
         return name;
@@ -75,7 +77,7 @@ public final class Reason {
         ReasonBuilder(final String name) {
             this.name = name;
         }
-        
+
         ReasonBuilder isRunOnMain(boolean isRunOnMain) {
             this.isRunOnMain = isRunOnMain;
             return this;

--- a/src/main/java/com/atlassian/db/replica/api/strategy/FallBackToMain.java
+++ b/src/main/java/com/atlassian/db/replica/api/strategy/FallBackToMain.java
@@ -1,0 +1,18 @@
+package com.atlassian.db.replica.api.strategy;
+
+import com.atlassian.db.replica.api.SqlCall;
+import com.atlassian.db.replica.spi.ReplicaFailureStrategy;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Usees main connection after replica failure.
+ */
+public class FallBackToMain implements ReplicaFailureStrategy {
+
+    @Override
+    public Connection onFailure(SQLException exception, SqlCall<Connection> mainConnection) throws SQLException {
+        return mainConnection.call();
+    }
+}

--- a/src/main/java/com/atlassian/db/replica/api/strategy/PropagateReplicaFailure.java
+++ b/src/main/java/com/atlassian/db/replica/api/strategy/PropagateReplicaFailure.java
@@ -1,0 +1,17 @@
+package com.atlassian.db.replica.api.strategy;
+
+import com.atlassian.db.replica.api.SqlCall;
+import com.atlassian.db.replica.spi.ReplicaFailureStrategy;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Propagates replica failure.
+ */
+public class PropagateReplicaFailure implements ReplicaFailureStrategy {
+    @Override
+    public Connection onFailure(SQLException exception, SqlCall<Connection> mainConnection) throws SQLException {
+        throw exception;
+    }
+}

--- a/src/main/java/com/atlassian/db/replica/internal/ReplicaConnectionProvider.java
+++ b/src/main/java/com/atlassian/db/replica/internal/ReplicaConnectionProvider.java
@@ -7,6 +7,7 @@ import com.atlassian.db.replica.internal.state.State;
 import com.atlassian.db.replica.internal.state.StateListener;
 import com.atlassian.db.replica.spi.ConnectionProvider;
 import com.atlassian.db.replica.spi.ReplicaConsistency;
+import com.atlassian.db.replica.spi.ReplicaFailureStrategy;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -28,7 +29,8 @@ public class ReplicaConnectionProvider implements AutoCloseable {
     public ReplicaConnectionProvider(
         ConnectionProvider connectionProvider,
         ReplicaConsistency consistency,
-        StateListener stateListener
+        StateListener stateListener,
+        ReplicaFailureStrategy replicaFailureStrategy
     ) {
         this.parameters = new ConnectionParameters();
         this.warnings = new Warnings();
@@ -37,8 +39,8 @@ public class ReplicaConnectionProvider implements AutoCloseable {
             consistency,
             parameters,
             warnings,
-            stateListener
-        );
+            stateListener,
+            replicaFailureStrategy);
         this.consistency = consistency;
     }
 

--- a/src/main/java/com/atlassian/db/replica/spi/ReplicaFailureStrategy.java
+++ b/src/main/java/com/atlassian/db/replica/spi/ReplicaFailureStrategy.java
@@ -1,0 +1,14 @@
+package com.atlassian.db.replica.spi;
+
+
+import com.atlassian.db.replica.api.SqlCall;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public interface ReplicaFailureStrategy {
+    /**
+     * Controls replica failures.
+     */
+    Connection onFailure(SQLException exception, SqlCall<Connection> mainConnection) throws SQLException;
+}

--- a/src/test/java/com/atlassian/db/replica/api/mocks/ConnectionProviderMock.java
+++ b/src/test/java/com/atlassian/db/replica/api/mocks/ConnectionProviderMock.java
@@ -96,7 +96,7 @@ public class ConnectionProviderMock implements ConnectionProvider {
     }
 
     @Override
-    public Connection getReplicaConnection() {
+    public Connection getReplicaConnection() throws SQLException {
         providedConnectionTypes.add(ConnectionType.REPLICA);
         final Connection connection = getConnection();
         setWarning(connection, replicaWarning);


### PR DESCRIPTION
Currently, when DualConnection fails to get a replica connection,
the exception is propagated. In case of replica failure, there's
no way to fall back to the main database. The new SPI allows controlling failures.