### PR TITLE
During replica consistency checking replica node may not be available

### DIFF
--- a/src/main/java/com/atlassian/db/replica/internal/NotLoggingLogger.java
+++ b/src/main/java/com/atlassian/db/replica/internal/NotLoggingLogger.java
@@ -1,0 +1,6 @@
+package com.atlassian.db.replica.internal;
+
+import com.atlassian.db.replica.spi.Logger;
+
+public class NotLoggingLogger implements Logger {
+}

--- a/src/main/java/com/atlassian/db/replica/spi/Logger.java
+++ b/src/main/java/com/atlassian/db/replica/spi/Logger.java
@@ -1,0 +1,21 @@
+package com.atlassian.db.replica.spi;
+
+public interface Logger {
+
+    default void debug(String message) {}
+
+    default void debug(String message, Throwable t) {}
+
+    default void info(String message) {}
+
+    default void info(String message, Throwable t) {}
+
+    default void warn(String message) {}
+
+    default void warn(String message, Throwable t) {}
+
+    default void error(String message) {}
+
+    default void error(String message, Throwable t) {}
+
+}


### PR DESCRIPTION
…. Following exceptions are symptoms of that behaviour:

- org.postgresql.util.PSQLException: FATAL: the database system is starting up
- org.postgresql.util.PSQLException: Connection to <replica_host:port> refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.

It looks that aurora function `aurora_replica_status()` which is used to discover replicas in the Aurora cluster returns replicas even when they are not ready to serve load and are not present behind load-balanced cluster url.