### PR TITLE
JCES-2328: Add support for `clusterUri` in `AuroraMultiReplicaConsist…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-2.5.6...master
 
+### Add
+- Support for `clusterUri` in `AuroraMultiReplicaConsistency`
+
 ## [2.5.6] - 2021-12-20
 [2.5.6]: https://github.com/atlassian-labs/db-replica/compare/release-2.5.4...release-2.5.6
 

--- a/src/main/java/com/atlassian/db/replica/api/AuroraMultiReplicaConsistency.java
+++ b/src/main/java/com/atlassian/db/replica/api/AuroraMultiReplicaConsistency.java
@@ -24,13 +24,15 @@ public final class AuroraMultiReplicaConsistency implements ReplicaConsistency {
         Logger logger,
         ReplicaConsistency replicaConsistency,
         ReplicaConnectionPerUrlProvider replicaConnectionPerUrlProvider,
-        SuppliedCache<Collection<Database>> discoveredReplicasCache
+        SuppliedCache<Collection<Database>> discoveredReplicasCache,
+        String clusterUri
     ) {
         this.logger = logger;
         this.replicaConsistency = replicaConsistency;
         this.cluster = AuroraClusterDiscovery.builder()
             .replicaConnectionPerUrlProvider(replicaConnectionPerUrlProvider)
             .discoveredReplicasCache(discoveredReplicasCache)
+            .clusterUri(clusterUri)
             .build();
     }
 
@@ -64,6 +66,7 @@ public final class AuroraMultiReplicaConsistency implements ReplicaConsistency {
         private ReplicaConnectionPerUrlProvider replicaConnectionPerUrlProvider;
         private SuppliedCache<Collection<Database>> discoveredReplicasCache = new NoCacheSuppliedCache<>();
         private Logger logger = new NotLoggingLogger();
+        private String clusterUri;
 
         public Builder replicaConsistency(ReplicaConsistency replicaConsistency) {
             this.replicaConsistency = replicaConsistency;
@@ -77,6 +80,11 @@ public final class AuroraMultiReplicaConsistency implements ReplicaConsistency {
 
         public Builder logger(Logger logger) {
             this.logger = logger;
+            return this;
+        }
+
+        public Builder clusterUri(String clusterUri) {
+            this.clusterUri = clusterUri;
             return this;
         }
 
@@ -111,7 +119,8 @@ public final class AuroraMultiReplicaConsistency implements ReplicaConsistency {
                 logger,
                 replicaConsistency,
                 replicaConnectionPerUrlProvider,
-                discoveredReplicasCache
+                discoveredReplicasCache,
+                clusterUri
             );
         }
     }

--- a/src/main/java/com/atlassian/db/replica/internal/aurora/AuroraClusterDiscovery.java
+++ b/src/main/java/com/atlassian/db/replica/internal/aurora/AuroraClusterDiscovery.java
@@ -1,8 +1,8 @@
 package com.atlassian.db.replica.internal.aurora;
 
 import com.atlassian.db.replica.api.AuroraConnectionDetails;
-import com.atlassian.db.replica.api.jdbc.JdbcUrl;
 import com.atlassian.db.replica.api.Database;
+import com.atlassian.db.replica.api.jdbc.JdbcUrl;
 import com.atlassian.db.replica.internal.NoCacheSuppliedCache;
 import com.atlassian.db.replica.spi.ReplicaConnectionPerUrlProvider;
 import com.atlassian.db.replica.spi.SuppliedCache;
@@ -18,13 +18,16 @@ import static java.util.stream.Collectors.toList;
 public final class AuroraClusterDiscovery {
     private final ReplicaConnectionPerUrlProvider replicaConnectionPerUrlProvider;
     private final SuppliedCache<Collection<Database>> discoveredReplicasCache;
+    private final String clusterUri;
 
     private AuroraClusterDiscovery(
         ReplicaConnectionPerUrlProvider replicaConnectionPerUrlProvider,
-        SuppliedCache<Collection<Database>> discoveredReplicasCache
+        SuppliedCache<Collection<Database>> discoveredReplicasCache,
+        String clusterUri
     ) {
         this.replicaConnectionPerUrlProvider = replicaConnectionPerUrlProvider;
         this.discoveredReplicasCache = discoveredReplicasCache;
+        this.clusterUri = clusterUri;
     }
 
     public Collection<Database> getReplicas(Supplier<Connection> connectionSupplier) {
@@ -51,6 +54,14 @@ public final class AuroraClusterDiscovery {
     }
 
     private AuroraReplicasDiscoverer createDiscoverer(Connection connection) {
+        if (this.clusterUri != null) {
+            return createDiscovererFromClusterUri();
+        } else {
+            return createDiscovererFromConnection(connection);
+        }
+    }
+
+    private AuroraReplicasDiscoverer createDiscovererFromConnection(Connection connection) {
         try {
             final String databaseUrl = connection.getMetaData().getURL();
             final String[] split = databaseUrl.split("/");
@@ -64,6 +75,15 @@ public final class AuroraClusterDiscovery {
         }
     }
 
+    private AuroraReplicasDiscoverer createDiscovererFromClusterUri() {
+        final String[] split = clusterUri.split("/");
+        final String readerEndpoint = split[2];
+        final String databaseName = split[3];
+        return new AuroraReplicasDiscoverer(
+            new AuroraJdbcUrl(AuroraEndpoint.parse(readerEndpoint), databaseName)
+        );
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -71,6 +91,7 @@ public final class AuroraClusterDiscovery {
     public static final class Builder {
         private ReplicaConnectionPerUrlProvider replicaConnectionPerUrlProvider;
         private SuppliedCache<Collection<Database>> discoveredReplicasCache = new NoCacheSuppliedCache<>();
+        private String clusterUri;
 
         public Builder replicaConnectionPerUrlProvider(ReplicaConnectionPerUrlProvider replicaConnectionPerUrlProvider) {
             this.replicaConnectionPerUrlProvider = replicaConnectionPerUrlProvider;
@@ -79,6 +100,11 @@ public final class AuroraClusterDiscovery {
 
         public Builder discoveredReplicasCache(SuppliedCache<Collection<Database>> discoveredReplicasCache) {
             this.discoveredReplicasCache = discoveredReplicasCache;
+            return this;
+        }
+
+        public Builder clusterUri(String clusterUri) {
+            this.clusterUri = clusterUri;
             return this;
         }
 
@@ -94,7 +120,7 @@ public final class AuroraClusterDiscovery {
         }
 
         public AuroraClusterDiscovery build() {
-            return new AuroraClusterDiscovery(replicaConnectionPerUrlProvider, discoveredReplicasCache);
+            return new AuroraClusterDiscovery(replicaConnectionPerUrlProvider, discoveredReplicasCache, clusterUri);
         }
     }
 


### PR DESCRIPTION
…ency`

By default, the cluster URI is obtained from the provided connection in
`isConsistent` method. The provided connection doesn't have to use
cluster URI. The new method allows setting the URI explicitly.