### PR TITLE
Migrate to artifact publish token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -37,11 +40,15 @@ jobs:
       with:
         name: pitest-reports
         path: build/reports/pitest
+    - name: Get publish token
+      id: publish-token
+      if: github.event.inputs.release != null && github.event.inputs.release != 'None'
+      uses: atlassian-labs/artifact-publish-token@v1.0.1
     - name: Release
       if: github.event.inputs.release != null && github.event.inputs.release != 'None'
       env:
-        atlassian_private_username: ${{ secrets.ARTIFACTORY_USERNAME }}
-        atlassian_private_password: ${{ secrets.ARTIFACTORY_API_KEY }}
+        atlassian_private_username: ${{ steps.publish-token.outputs.artifactoryUsername }}
+        atlassian_private_password: ${{ steps.publish-token.outputs.artifactoryApiKey }}
       run: |
         ./gradlew markNextVersion -Prelease.incrementer=increment${{ github.event.inputs.release }} -Prelease.localOnly
         ./gradlew release -Prelease.customUsername=${{ secrets.REPOSITORY_ACCESS_TOKEN }}


### PR DESCRIPTION
Artifactory secrets are being deprecated.

This change replaces secrets with an equivalent ephemeral publish token.
