### PR TITLE
Throw `ReadReplicaConnectionCreationException` when failing to connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-2.6.4...master
 
+### Add
+- Throw `ReadReplicaConnectionCreationException` when failing to connect to a replica
+
 ## [2.6.4] - 2022-07-01
 [2.6.4]: https://github.com/atlassian-labs/db-replica/compare/release-2.6.2...release-2.6.4
 

--- a/src/main/java/com/atlassian/db/replica/api/AuroraMultiReplicaConsistency.java
+++ b/src/main/java/com/atlassian/db/replica/api/AuroraMultiReplicaConsistency.java
@@ -5,7 +5,7 @@ import com.atlassian.db.replica.internal.LazyReference;
 import com.atlassian.db.replica.internal.NoCacheSuppliedCache;
 import com.atlassian.db.replica.internal.NotLoggingLogger;
 import com.atlassian.db.replica.internal.aurora.AuroraClusterDiscovery;
-import com.atlassian.db.replica.internal.aurora.ReadReplicaConnectionCreationException;
+import com.atlassian.db.replica.api.exception.ReadReplicaConnectionCreationException;
 import com.atlassian.db.replica.spi.Logger;
 import com.atlassian.db.replica.spi.ReplicaConnectionPerUrlProvider;
 import com.atlassian.db.replica.spi.ReplicaConsistency;

--- a/src/main/java/com/atlassian/db/replica/api/exception/ReadReplicaConnectionCreationException.java
+++ b/src/main/java/com/atlassian/db/replica/api/exception/ReadReplicaConnectionCreationException.java
@@ -1,4 +1,4 @@
-package com.atlassian.db.replica.internal.aurora;
+package com.atlassian.db.replica.api.exception;
 
 public class ReadReplicaConnectionCreationException extends RuntimeException {
 

--- a/src/main/java/com/atlassian/db/replica/internal/aurora/AuroraReplicaNode.java
+++ b/src/main/java/com/atlassian/db/replica/internal/aurora/AuroraReplicaNode.java
@@ -1,5 +1,6 @@
 package com.atlassian.db.replica.internal.aurora;
 
+import com.atlassian.db.replica.api.exception.ReadReplicaConnectionCreationException;
 import com.atlassian.db.replica.spi.ReplicaConnectionProvider;
 import com.atlassian.db.replica.api.Database;
 


### PR DESCRIPTION
Throw `ReadReplicaConnectionCreationException` when failing to connect to a replica

I want to clean up all the usages of internals in the product. I need to promote
the exception to the API.