### PR TITLE
Issue/none lsn not propagated after close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 - Avoid unnecessary switch to `MainConnection` while setting `read-only` mode
 - Statement Behavior changes don't affect DualConnection's state
 
+### Added
+- Add `DirtyConnectionCloseHook`
+
 ## [0.1.24] - 2021-02-16
 [0.1.24]: https://github.com/atlassian-labs/db-replica/compare/release-0.1.23...release-0.1.24
 

--- a/src/main/java/com/atlassian/db/replica/internal/NoOpDirtyConnectionCloseHook.java
+++ b/src/main/java/com/atlassian/db/replica/internal/NoOpDirtyConnectionCloseHook.java
@@ -1,0 +1,12 @@
+package com.atlassian.db.replica.internal;
+
+import com.atlassian.db.replica.spi.DirtyConnectionCloseHook;
+
+import java.sql.Connection;
+
+public class NoOpDirtyConnectionCloseHook implements DirtyConnectionCloseHook {
+    @Override
+    public void onClose(Connection connection) {
+        // do nothing
+    }
+}

--- a/src/main/java/com/atlassian/db/replica/internal/ReplicaConnectionProvider.java
+++ b/src/main/java/com/atlassian/db/replica/internal/ReplicaConnectionProvider.java
@@ -175,6 +175,7 @@ public class ReplicaConnectionProvider implements AutoCloseable {
         final Optional<Connection> connection = state.getConnection();
         if (connection.isPresent()) {
             connection.get().rollback();
+            state.clearDirty();
         }
     }
 
@@ -191,6 +192,7 @@ public class ReplicaConnectionProvider implements AutoCloseable {
         if (state.getState().equals(MAIN) && !autoCommit) {
             final Connection mainConnection = state.getWriteConnection(new RouteDecisionBuilder(Reason.RW_API_CALL));
             consistency.write(mainConnection);
+            state.clearDirty();
         }
     }
 
@@ -200,7 +202,13 @@ public class ReplicaConnectionProvider implements AutoCloseable {
             consistency.preCommit(mainConnection);
         }
     }
+    public void markConnectionDirty(){
+        this.state.markDirty();
+    }
 
+    public boolean isDirty(){
+        return this.state.isDirty();
+    }
     @Override
     public void close() throws SQLException {
         state.close();

--- a/src/main/java/com/atlassian/db/replica/internal/ReplicaStatement.java
+++ b/src/main/java/com/atlassian/db/replica/internal/ReplicaStatement.java
@@ -575,6 +575,8 @@ public class ReplicaStatement implements Statement {
         final Connection connection = currentStatement.getConnection();
         if (connection.getAutoCommit()) {
             consistency.write(connection);
+        } else {
+            connectionProvider.markConnectionDirty();
         }
     }
 

--- a/src/main/java/com/atlassian/db/replica/internal/state/ConnectionState.java
+++ b/src/main/java/com/atlassian/db/replica/internal/state/ConnectionState.java
@@ -37,6 +37,28 @@ public final class ConnectionState {
     private final DecisionAwareReference<Connection> readConnection;
     private final DecisionAwareReference<Connection> writeConnection;
 
+    /**
+     * When we use a connection to write to the database, it becomes a 'dirty' connection.
+     * The state is cleared when we commit the transaction. Currently, we use it only
+     * to detect dirty connection close() and commit the transaction before closing
+     * the connection.
+     * In the future we can use this state to exit `MainConnection` state and move more traffic to replicas.
+     * (see <a href="https://github.com/atlassian-labs/db-replica/blob/master/docs/dual-connection-states.png">Dual connection states</a>).
+     */
+    private volatile boolean dirty = false;
+
+    public void markDirty() {
+        this.dirty = true;
+    }
+
+    public void clearDirty() {
+        this.dirty = false;
+    }
+
+    public boolean isDirty(){
+        return dirty;
+    }
+
     public ConnectionState(
         ConnectionProvider connectionProvider,
         ReplicaConsistency consistency,

--- a/src/main/java/com/atlassian/db/replica/spi/DirtyConnectionCloseHook.java
+++ b/src/main/java/com/atlassian/db/replica/spi/DirtyConnectionCloseHook.java
@@ -1,0 +1,11 @@
+package com.atlassian.db.replica.spi;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * The hook will be invoked before closing a connection with uncommitted data.
+ */
+public interface DirtyConnectionCloseHook {
+    void onClose(Connection connection) throws SQLException;
+}

--- a/src/test/java/com/atlassian/db/replica/api/TestDualConnection.java
+++ b/src/test/java/com/atlassian/db/replica/api/TestDualConnection.java
@@ -1746,7 +1746,8 @@ public class TestDualConnection {
                 .assumeMaxPropagation(Duration.ofDays(10))
                 .cacheLastWrite(lastWriteCache)
                 .build()
-        ).build();
+        ).dirtyConnectionCloseHook(Connection::commit)
+            .build();
         connection.setAutoCommit(false);
         connection.prepareStatement(SIMPLE_QUERY).executeUpdate();
         connection.close();


### PR DESCRIPTION
I think it may be the issue we observe in the product:
1. We get a connection from the `transaction-thread local`.
2. We prepare a statement and `executeUpdate` without calling `commit`.
3. We close the connection

The transaction is never committed on the DualConnection layer, so we never
register ReplicaConsistency#write, and we don't store the last write.
The following connection assumes the replica is consistent.

Why was the data persistent by the update without calling `commit`?

It's because we have a hook:
```
.addOnClose((rawConnection, timeTaken) -> {
                boolean autocommit = rawConnection.getAutoCommit();
                if (!autocommit) {
                    rawConnection.setAutoCommit(true);
                }
            });
```
The hook calls setAutoCommit(true) if the auto-comit was set to false,
and according to the Connection docs:
"If this method is called during a transaction and the
 auto-commit mode is changed, the transaction is committed.".