### PR TITLE
JCES-2607: Don't call `DirtyConnectionHook` after rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ### Fixed
 - Set connection runtime parameters, after switching to the main connection (cover uppercase SET)
+- Don't call `DirtyConnectionHook` after rollback
 
 ## [2.7.0] - 2022-09-08
 [2.7.0]: https://github.com/atlassian-labs/db-replica/compare/release-2.6.4...release-2.7.0

--- a/src/main/java/com/atlassian/db/replica/internal/ReplicaConnectionProvider.java
+++ b/src/main/java/com/atlassian/db/replica/internal/ReplicaConnectionProvider.java
@@ -172,10 +172,10 @@ public class ReplicaConnectionProvider implements AutoCloseable {
     }
 
     public void rollback() throws SQLException {
+        state.clearDirty();
         final Optional<Connection> connection = state.getConnection();
         if (connection.isPresent()) {
             connection.get().rollback();
-            state.clearDirty();
         }
     }
 


### PR DESCRIPTION
We had lots of false positive calls for the scenario.

```
 connection.setAutoCommit(false);
try{ 
connection.prepareStatement(SIMPLE_QUERY).executeUpdate();
}finally{
connection.rollback()
}
...
...
connection.close()
```