### PR TITLE
Issue/none remove internal imports from product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-2.8.0...master
 
+### Added
+- `ReadReplicaConnectionCreationException`
+
 ## [2.8.0] - 2022-10-04
 [2.8.0]: https://github.com/atlassian-labs/db-replica/compare/release-2.7.2...release-2.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-2.7.2...master
+[Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-2.8.0...master
+
+## [2.8.0] - 2022-10-04
+[2.8.0]: https://github.com/atlassian-labs/db-replica/compare/release-2.7.2...release-2.8.0
 
 ### Added
 - Logger for tracking `DualConnection` internal actions

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Maven:
 <dependency>
     <groupId>com.atlassian.db.replica</groupId>
     <artifactId>db-replica</artifactId>
-    <version>2.7.2</version>
+    <version>2.8.0</version>
 </dependency>
 ```
 

--- a/src/main/java/com/atlassian/db/replica/api/AuroraMultiReplicaConsistency.java
+++ b/src/main/java/com/atlassian/db/replica/api/AuroraMultiReplicaConsistency.java
@@ -5,7 +5,7 @@ import com.atlassian.db.replica.internal.LazyReference;
 import com.atlassian.db.replica.internal.NoCacheSuppliedCache;
 import com.atlassian.db.replica.internal.NotLoggingLogger;
 import com.atlassian.db.replica.internal.aurora.AuroraClusterDiscovery;
-import com.atlassian.db.replica.internal.aurora.ReadReplicaConnectionCreationException;
+import com.atlassian.db.replica.api.exception.ReadReplicaConnectionCreationException;
 import com.atlassian.db.replica.spi.Logger;
 import com.atlassian.db.replica.spi.ReplicaConnectionPerUrlProvider;
 import com.atlassian.db.replica.spi.ReplicaConsistency;

--- a/src/main/java/com/atlassian/db/replica/api/exception/ReadReplicaConnectionCreationException.java
+++ b/src/main/java/com/atlassian/db/replica/api/exception/ReadReplicaConnectionCreationException.java
@@ -1,4 +1,4 @@
-package com.atlassian.db.replica.internal.aurora;
+package com.atlassian.db.replica.api.exception;
 
 public class ReadReplicaConnectionCreationException extends RuntimeException {
 

--- a/src/main/java/com/atlassian/db/replica/internal/ReplicaPreparedStatement.java
+++ b/src/main/java/com/atlassian/db/replica/internal/ReplicaPreparedStatement.java
@@ -709,4 +709,11 @@ public class ReplicaPreparedStatement extends ReplicaStatement implements Prepar
             );
         }
     }
+
+    @Override
+    public String toString() {
+        return getCurrentStatement() != null ?
+            getCurrentStatement().toString() :
+            getClass().getName() + "@" + Integer.toHexString(hashCode());
+    }
 }

--- a/src/main/java/com/atlassian/db/replica/internal/aurora/AuroraReplicaNode.java
+++ b/src/main/java/com/atlassian/db/replica/internal/aurora/AuroraReplicaNode.java
@@ -1,5 +1,6 @@
 package com.atlassian.db.replica.internal.aurora;
 
+import com.atlassian.db.replica.api.exception.ReadReplicaConnectionCreationException;
 import com.atlassian.db.replica.spi.ReplicaConnectionProvider;
 import com.atlassian.db.replica.api.Database;
 


### PR DESCRIPTION
During the last months, some `replcia.internal` dependencies sneaked into the product. I plan to remove them but needed to do some changes in db.replica to make it happen.