### PR TITLE
Change "getMetaData()" to use a read connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/db-replica/compare/release-2.9.0...master
 
+- Default `getMetaData()` method in `DualConnection` to use read connection
+
 ## [2.9.0] - 2022-10-10
 [2.9.0]: https://github.com/atlassian-labs/db-replica/compare/release-2.8.0...release-2.9.0
 

--- a/src/main/java/com/atlassian/db/replica/api/DualConnection.java
+++ b/src/main/java/com/atlassian/db/replica/api/DualConnection.java
@@ -182,7 +182,7 @@ public final class DualConnection implements Connection {
     @Override
     public DatabaseMetaData getMetaData() throws SQLException {
         checkClosed();
-        return connectionProvider.getWriteConnection(new RouteDecisionBuilder(Reason.RW_API_CALL)).getMetaData();
+        return connectionProvider.getReadConnection(new RouteDecisionBuilder(Reason.RO_API_CALL)).getMetaData();
     }
 
     @Override


### PR DESCRIPTION
The `getMetaData()` method on `DualConnection` can be called at anytime during the lifetime of the connection.

In the current behaviour, when `getMetaData()` is called right after the construction of a `DualConnection`, it will pinned the connection to always use the write instance. During heavy read-only operations, this can lead to unintended saturation of the writer instance when the reader instances still have capacity.

This is mostly problematic for telemetry agents such the OpenTelemetry Java agent as these agents will always call `getMetaData()` before any `execute` methods, pinning the connection to use the write instance even when the connection will only ever be used for reads.

This PR changes the behaviour of the `getMetaData()` method on `DualConnection` to use the read connection but makes the following trade off.

If `getMetaData()` is called right before a DML query, the meta data returned will be for the read connection rather than the write. This may be problematic for the caller however in most cases, the meta data from both the read and write connections will largely be the same (except for connection URL).
