### PR TITLE
Change "getClientInfo()" to use a read connection

### DIFF
--- a/src/main/java/com/atlassian/db/replica/api/DualConnection.java
+++ b/src/main/java/com/atlassian/db/replica/api/DualConnection.java
@@ -545,17 +545,29 @@ public final class DualConnection implements Connection {
     @Override
     public String getClientInfo(String name) throws SQLException {
         checkClosed();
-        return connectionProvider
-            .getWriteConnection(new RouteDecisionBuilder(Reason.RW_API_CALL))
-            .getClientInfo(name);
+        if (compatibleWithPreviousVersion) {
+            return connectionProvider
+                .getWriteConnection(new RouteDecisionBuilder(Reason.RW_API_CALL))
+                .getClientInfo(name);
+        } else {
+            return connectionProvider
+                .getReadConnection(new RouteDecisionBuilder(Reason.RO_API_CALL))
+                .getClientInfo(name);
+        }
     }
 
     @Override
     public Properties getClientInfo() throws SQLException {
         checkClosed();
-        return connectionProvider
-            .getWriteConnection(new RouteDecisionBuilder(Reason.RW_API_CALL))
-            .getClientInfo();
+        if (compatibleWithPreviousVersion) {
+            return connectionProvider
+                .getWriteConnection(new RouteDecisionBuilder(Reason.RW_API_CALL))
+                .getClientInfo();
+        } else {
+            return connectionProvider
+                .getReadConnection(new RouteDecisionBuilder(Reason.RO_API_CALL))
+                .getClientInfo();
+        }
     }
 
     @Override

--- a/src/test/java/com/atlassian/db/replica/api/TestDualConnection.java
+++ b/src/test/java/com/atlassian/db/replica/api/TestDualConnection.java
@@ -968,7 +968,6 @@ public class TestDualConnection {
         verify(connectionProvider.singleProvidedConnection()).getMetaData();
     }
 
-
     @Test
     public void shouldGetMetaDataFromReplicaAfterRead() throws SQLException {
         final ConnectionProviderMock connectionProvider = new ConnectionProviderMock();
@@ -985,7 +984,6 @@ public class TestDualConnection {
         verify(connectionProvider.singleProvidedConnection()).getMetaData();
     }
 
-
     @Test
     public void shouldGetMetaDataFromMainAfterWrite() throws SQLException {
         final ConnectionProviderMock connectionProvider = new ConnectionProviderMock();
@@ -1000,6 +998,100 @@ public class TestDualConnection {
         assertThat(connectionProvider.getProvidedConnectionTypes())
             .containsExactly(MAIN);
         verify(connectionProvider.singleProvidedConnection()).getMetaData();
+    }
+
+    @Test
+    public void shouldGetClientInfoFromReplicaWhenConnectionNotInitialised() throws SQLException {
+        final ConnectionProviderMock connectionProvider = new ConnectionProviderMock();
+        final Connection connection = DualConnection.builder(
+            connectionProvider,
+            permanentConsistency().build()
+        ).build();
+
+        connection.getClientInfo();
+
+        assertThat(connectionProvider.getProvidedConnectionTypes())
+            .containsOnly(REPLICA);
+        verify(connectionProvider.singleProvidedConnection()).getClientInfo();
+    }
+
+    @Test
+    public void shouldGetClientInfoFromReplicaAfterRead() throws SQLException {
+        final ConnectionProviderMock connectionProvider = new ConnectionProviderMock();
+        final Connection connection = DualConnection.builder(
+            connectionProvider,
+            permanentConsistency().build()
+        ).build();
+
+        connection.prepareStatement(SIMPLE_QUERY).executeQuery();
+        connection.getClientInfo();
+
+        assertThat(connectionProvider.getProvidedConnectionTypes())
+            .containsExactly(REPLICA);
+        verify(connectionProvider.singleProvidedConnection()).getClientInfo();
+    }
+
+    @Test
+    public void shouldGetClientInfoFromMainAfterWrite() throws SQLException {
+        final ConnectionProviderMock connectionProvider = new ConnectionProviderMock();
+        final Connection connection = DualConnection.builder(
+            connectionProvider,
+            permanentConsistency().build()
+        ).build();
+
+        connection.prepareStatement(SIMPLE_QUERY).executeUpdate();
+        connection.getClientInfo();
+
+        assertThat(connectionProvider.getProvidedConnectionTypes())
+            .containsExactly(MAIN);
+        verify(connectionProvider.singleProvidedConnection()).getClientInfo();
+    }
+
+    @Test
+    public void shouldGetClientInfoWithNameFromReplicaWhenConnectionNotInitialised() throws SQLException {
+        final ConnectionProviderMock connectionProvider = new ConnectionProviderMock();
+        final Connection connection = DualConnection.builder(
+            connectionProvider,
+            permanentConsistency().build()
+        ).build();
+
+        connection.getClientInfo("abcdef");
+
+        assertThat(connectionProvider.getProvidedConnectionTypes())
+            .containsOnly(REPLICA);
+        verify(connectionProvider.singleProvidedConnection()).getClientInfo("abcdef");
+    }
+
+    @Test
+    public void shouldGetClientInfoWithNameFromReplicaAfterRead() throws SQLException {
+        final ConnectionProviderMock connectionProvider = new ConnectionProviderMock();
+        final Connection connection = DualConnection.builder(
+            connectionProvider,
+            permanentConsistency().build()
+        ).build();
+
+        connection.prepareStatement(SIMPLE_QUERY).executeQuery();
+        connection.getClientInfo("ghijkl");
+
+        assertThat(connectionProvider.getProvidedConnectionTypes())
+            .containsExactly(REPLICA);
+        verify(connectionProvider.singleProvidedConnection()).getClientInfo("ghijkl");
+    }
+
+    @Test
+    public void shouldGetClientInfoWithNameFromMainAfterWrite() throws SQLException {
+        final ConnectionProviderMock connectionProvider = new ConnectionProviderMock();
+        final Connection connection = DualConnection.builder(
+            connectionProvider,
+            permanentConsistency().build()
+        ).build();
+
+        connection.prepareStatement(SIMPLE_QUERY).executeUpdate();
+        connection.getClientInfo("mnopqr");
+
+        assertThat(connectionProvider.getProvidedConnectionTypes())
+            .containsExactly(MAIN);
+        verify(connectionProvider.singleProvidedConnection()).getClientInfo("mnopqr");
     }
 
     @Test


### PR DESCRIPTION
This same issue as the one described in https://github.com/atlassian-labs/db-replica/pull/167 however this time it's the `getClientInfo()` method.

The `getClientInfo()` method on `DualConnection` can be called at anytime during the lifetime of the connection.

In the current behaviour, when `getClientInfo()` is called right after the construction of a `DualConnection`, it will pinned the connection to always use the write instance. During heavy read-only operations, this can lead to unintended saturation of the writer instance when the reader instances still have capacity.

This is mostly problematic for telemetry agents such the OpenTelemetry Java agent as these agents will always call `getClientInfo()` before any execute methods, pinning the connection to use the write instance even when the connection will only ever be used for reads.

This PR changes the behaviour of the `getClientInfo()` method on DualConnection to use the read connection but makes the following trade off.

If `getClientInfo()` is called right before a DML query, the properties returned will be for the read connection rather than the write. This may be problematic for the caller however in most cases, the properties from both the read and write connections will largely be the same with some variances.