### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @atlassian-labs/falcon
+* @atlassian-labs/jira-sre


### PR DESCRIPTION
Jira SRE is now the owner, leaving "Falcon" for consistency sake on PR merge/pulls.